### PR TITLE
Responsive Read More button

### DIFF
--- a/static/css/space-ros.css
+++ b/static/css/space-ros.css
@@ -1,0 +1,4 @@
+/* Makes the Read-More button responsive */
+.btn.btn-primary {
+  white-space: normal;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,8 @@
     <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/flexslider.css">
     <!-- Theme style  -->
     <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/style.css">
+    <!-- SpaceROS-related styles  -->
+    <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/space-ros.css">
     <!-- Custom style  -->
     <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/custom.css">
     <!-- pygments code highlight -->
@@ -94,7 +96,7 @@
 
         <div id="fh5co-main">
             {% block content %}{% endblock %}
-            {% include 'partial/copyright.html' %}                
+            {% include 'partial/copyright.html' %}
         </div>
     </div>
 
@@ -122,4 +124,3 @@
 
     </body>
 </html>
-


### PR DESCRIPTION
This PR addresses https://github.com/space-ros/spaceros.org/issues/2.

The Read More button now uses new lines if it doesn't have enough space.

A `space-ros` dedicated stylesheet will help us to keep track of changes included for the project.

Can you ptal @mjeronimo ?

---

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot from 2022-11-09 18-14-52](https://user-images.githubusercontent.com/14120807/200943332-e84e9cf6-9c77-40dc-81e0-8afe6a54467c.png) | ![localhost_8081_category_videos html (3)](https://user-images.githubusercontent.com/14120807/200942635-60d30091-e865-43c0-9d45-fd52d521b0fb.png) |


## GIF

![spaceROS-read-more-002](https://user-images.githubusercontent.com/14120807/200933964-4b8f98bd-6d81-4889-8c6a-8dcff30b3c1c.gif)
