### PR TITLE
Flex container for Articles

### DIFF
--- a/static/css/space-ros.css
+++ b/static/css/space-ros.css
@@ -1,4 +1,30 @@
 /* Makes the Read-More button responsive */
-.btn.btn-primary {
+.space-ros.btn.btn-primary {
   white-space: normal;
+  display: block;
+  margin-top: auto;
+}
+
+/* Article Teaser related styles - Makes the article list responsive using flexbox. */
+.space-ros.flex-container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.space-ros.blog-entry {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  float: none;
+}
+
+.space-ros.desc {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding-top: 0;
+}
+
+.space-ros.desc h3 {
+  margin-top: 0;
 }

--- a/templates/author.html
+++ b/templates/author.html
@@ -10,9 +10,7 @@
         <h1 class="fh5co-heading-colored">{{ author }}</h1>
 
         <div class="animate-box" data-animate-effect="fadeInLeft">
-          {% for article in articles %}
-            {% include 'partial/articleTeaser.html' %}
-          {% endfor %}
+            {% include 'partial/flexArticleContainer' %}
         </div>
     </div>
 {% endblock %}

--- a/templates/category.html
+++ b/templates/category.html
@@ -3,8 +3,6 @@
 {% block content %}
     <div class="fh5co-narrow-content">
         <h1 class="fh5co-heading-colored"><i class="icon-folder"></i> {{ category }}</h1>
-        {% for article in articles %}
-            {% include 'partial/articleTeaser.html' %}
-        {% endfor %}
+        {% include 'partial/flexArticleContainer' %}
     </div>
 {% endblock %}

--- a/templates/partial/articleTeaser.html
+++ b/templates/partial/articleTeaser.html
@@ -1,13 +1,13 @@
 <div class="col-md-3 col-sm-6 col-padding animate-box" data-animate-effect="fadeInLeft">
-    <div class="blog-entry">
+    <div class="space-ros blog-entry">
         {% if article.image is defined %}
             <a href="{{ SITEURL }}/{{ article.url }}" class="blog-img"><img src="{{ SITEURL }}/{{ article.image }}" class="img-responsive" alt="{{ article.title }}"></a>
         {% endif %}
-        <div class="desc">
+        <div class="space-ros desc">
             <h3><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h3>
             <span><small>Posted on {{ article.locale_date }}</small></span>
             <p>{{ article.summary }}</p>
-            <a href="{{ SITEURL }}/{{ article.url }}" class="btn btn-primary">{{ _('Read more') }} <i class="icon-arrow-right3"></i></a>
+            <a href="{{ SITEURL }}/{{ article.url }}" class="space-ros btn btn-primary">{{ _('Read more') }} <i class="icon-arrow-right3"></i></a>
         </div>
     </div>
 </div>

--- a/templates/partial/flexArticleContainer.html
+++ b/templates/partial/flexArticleContainer.html
@@ -1,0 +1,5 @@
+<div class="space-ros flex-container">
+    {% for article in articles %}
+        {% include 'partial/articleTeaser.html' %}
+    {% endfor %}
+</div>

--- a/templates/partial/latest.html
+++ b/templates/partial/latest.html
@@ -1,9 +1,10 @@
 {% if articles|length > 0 %}
-    <div class="fh5co-narrow-content">
+<div class="fh5co-narrow-content">
     <h2 class="fh5co-heading animate-box" data-animate-effect="fadeInLeft">{{ _('Recent articles') }}</h2>
     <div class="row row-bottom-padded-md">
-        {% for article in articles[0:4] %}
-            {% include 'partial/articleTeaser.html' %}
-        {% endfor %}
+        {% with articles=articles[0:4] %}
+            {% include 'partial/flexArticleContainer' %}
+        {% endwith %}
     </div>
+</div>
 {% endif %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -3,8 +3,6 @@
 {% block content %}
     <div class="fh5co-narrow-content">
         <h1 class="fh5co-heading-colored"><i class="icon-folder"></i> {{ tag }}</h1>
-        {% for article in articles %}
-            {% include 'partial/articleTeaser.html' %}
-        {% endfor %}
+        {% include 'partial/flexArticleContainer' %}
     </div>
 {% endblock %}


### PR DESCRIPTION
This PR addresses https://github.com/space-ros/spaceros.org/issues/1.

Whenever we want to display articles, we now use a partial which wraps them in a `flex-box` container, which solves the layout issues seen in the Videos category, for example.

This also forces the articles to have the same height on each row, making the page look like a grid. The Read More button is aligned at the end of each article so they are all aligned between articles.

This new container is implemented in:
- Categories
- Tags
- The homepage's latest articles (which displays only 4 of them)
- Author page

---

Can you ptal @mjeronimo ? I attach a GIF showing a little bit of it's responsive behaviour. I tested on different screen sizes and see no artifacts.

---

## Screenshots
Right-click and open in a new tab to see it bigger.

| Before | After |
| --- | --- |
| ![localhost_8081_category_videos html (10)](https://user-images.githubusercontent.com/14120807/201430944-d0971e63-9773-4cec-a7c7-d74606beaba7.png) | ![localhost_8081_category_videos html (9)](https://user-images.githubusercontent.com/14120807/201430955-393e520e-98db-4d9b-8412-1c94101e2cca.png) |

## GIF

![spaceROS-flex-container-001](https://user-images.githubusercontent.com/14120807/201430655-2eeeffbd-973c-4b12-96d8-8e4f7eb379f3.gif)
