### PR TITLE
[Fix] Extension in partials

### DIFF
--- a/templates/author.html
+++ b/templates/author.html
@@ -10,7 +10,7 @@
         <h1 class="fh5co-heading-colored">{{ author }}</h1>
 
         <div class="animate-box" data-animate-effect="fadeInLeft">
-            {% include 'partial/flexArticleContainer' %}
+            {% include 'partial/flexArticleContainer.html' %}
         </div>
     </div>
 {% endblock %}

--- a/templates/category.html
+++ b/templates/category.html
@@ -3,6 +3,6 @@
 {% block content %}
     <div class="fh5co-narrow-content">
         <h1 class="fh5co-heading-colored"><i class="icon-folder"></i> {{ category }}</h1>
-        {% include 'partial/flexArticleContainer' %}
+        {% include 'partial/flexArticleContainer.html' %}
     </div>
 {% endblock %}

--- a/templates/partial/latest.html
+++ b/templates/partial/latest.html
@@ -3,7 +3,7 @@
     <h2 class="fh5co-heading animate-box" data-animate-effect="fadeInLeft">{{ _('Recent articles') }}</h2>
     <div class="row row-bottom-padded-md">
         {% with articles=articles[0:4] %}
-            {% include 'partial/flexArticleContainer' %}
+            {% include 'partial/flexArticleContainer.html' %}
         {% endwith %}
     </div>
 </div>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -3,6 +3,6 @@
 {% block content %}
     <div class="fh5co-narrow-content">
         <h1 class="fh5co-heading-colored"><i class="icon-folder"></i> {{ tag }}</h1>
-        {% include 'partial/flexArticleContainer' %}
+        {% include 'partial/flexArticleContainer.html' %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Small fix related to #2

Partials need to have the `html` extension for them to be properly recognized by Pelican. The recently added `flexArticleContainer` partial did not have one.

Can you ptal @mjeronimo ?