### PR TITLE
Responsive logo

### DIFF
--- a/static/css/space-ros.css
+++ b/static/css/space-ros.css
@@ -28,3 +28,20 @@
 .space-ros.desc h3 {
   margin-top: 0;
 }
+
+/* Responsive Logo */
+#fh5co-aside #fh5co-logo.space-ros {
+  background-color: #2c3553;
+  margin: 0 -1rem 30px;
+}
+
+#fh5co-aside #fh5co-logo.space-ros img {
+  width: 100%;
+  max-width: 300px;
+}
+
+@media screen and (max-width: 992px) {
+  #fh5co-aside #fh5co-logo.space-ros img {
+    max-width: 2em;
+  }
+}

--- a/static/css/space-ros.css
+++ b/static/css/space-ros.css
@@ -38,10 +38,11 @@
 #fh5co-aside #fh5co-logo.space-ros img {
   width: 100%;
   max-width: 300px;
+  max-height: 3em;
 }
 
 @media screen and (max-width: 992px) {
   #fh5co-aside #fh5co-logo.space-ros img {
-    max-width: 2em;
+    max-height: 2em;
   }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,7 +81,9 @@
             <h1 class="space-ros" id="fh5co-logo">
                 <a href="{{ SITEURL }}/index.html">
                     <picture>
+                        {% if LOGO_SMALL %}
                         <source srcset="{{ SITEURL }}/{{ LOGO_SMALL }}" media="(max-width: 992px)"/>
+                        {% endif %}
                         <source srcset="{{ SITEURL }}/{{ LOGO }}" media="(min-width: 993px)"/>
                         <img src="{{ SITEURL }}/{{ LOGO }}" />
                     </picture>

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,9 +78,13 @@
             </nav>
 -->
             <div class="clearfix"></div>
-            <h1  id="fh5co-logo">
+            <h1 class="space-ros" id="fh5co-logo">
                 <a href="{{ SITEURL }}/index.html">
-                    <img src="{{ SITEURL }}/{{ LOGO }}" />
+                    <picture>
+                        <source srcset="{{ SITEURL }}/{{ LOGO_SMALL }}" media="(max-width: 992px)"/>
+                        <source srcset="{{ SITEURL }}/{{ LOGO }}" media="(min-width: 993px)"/>
+                        <img src="{{ SITEURL }}/{{ LOGO }}" />
+                    </picture>
                 </a>
             </h1>
             <nav class="fh5co-main-menu" role="navigation">


### PR DESCRIPTION
This PR addresses https://github.com/space-ros/spaceros.org/issues/3

It includes various fixes:
- The logo is now responsive and takes the space of the sidenav (SpaceROS won't be cut this way)
- If the sceen is less than 992px wide, we use the small logo.
- The logo has a background color to cover all it's width.
- You can set a `LOGO_SMALL` image in the Pelican config file. If not set, it won't be used without breaking things.

**Note:** The SpaceROS website needs to implement the `LOGO_SMALL` variable.

---

Can you ptal @mjeronimo ? Let me know what do you think of the changes.

---

## Screenshots

### iPhone size

|  | Before | After |
| --- | --- | --- |
| Landscape | ![Screenshot from 2022-11-14 11-28-38](https://user-images.githubusercontent.com/14120807/201686229-9acbf45f-648d-45b0-ae72-15bc951ea4f9.png) | ![Screenshot from 2022-11-14 11-35-47](https://user-images.githubusercontent.com/14120807/201687184-9c5927a9-5d82-40c6-a35e-26bc8795342e.png) |
| Portrait | ![Screenshot from 2022-11-14 11-28-30](https://user-images.githubusercontent.com/14120807/201686224-af8b2c30-cb55-4103-9b92-6e60439c3d42.png) | ![Screenshot from 2022-11-14 10-24-40](https://user-images.githubusercontent.com/14120807/201684951-c76b2f55-0cf2-4ebf-aa34-e53767998758.png) |

### iPad size

|  | Before | After |
| --- | --- | --- |
| Landscape | ![Screenshot from 2022-11-14 11-28-49](https://user-images.githubusercontent.com/14120807/201686233-19302761-05ea-4bcf-93c8-68343d247d2a.png) | ![Screenshot from 2022-11-14 10-24-57](https://user-images.githubusercontent.com/14120807/201684961-946b9edd-f4a5-4c11-9c8e-f112124a5777.png) |
| Portrait | ![Screenshot from 2022-11-14 11-28-53](https://user-images.githubusercontent.com/14120807/201686238-aa63d3da-bb1c-4395-97ba-d0124046f455.png) | ![Screenshot from 2022-11-14 10-24-51](https://user-images.githubusercontent.com/14120807/201684953-e2033c91-a806-41f3-8d34-c85312e3aab7.png) |

---

## GIF

![spaceROS-responsive-logo-002](https://user-images.githubusercontent.com/14120807/201687325-4dd911e6-83c0-435e-86d8-b1221ad6e008.gif)





