### PR TITLE
Make text stand out the background images

### DIFF
--- a/static/css/space-ros.css
+++ b/static/css/space-ros.css
@@ -46,3 +46,13 @@
     max-height: 2em;
   }
 }
+
+/* Hero-related changes to make the text stand out */
+#fh5co-hero.space-ros .flexslider .slider-text > .slider-text-inner h1,
+#fh5co-hero.space-ros .flexslider .slider-text > .slider-text-inner h2 {
+  text-shadow: 0 0 5px #333333;
+}
+
+#fh5co-hero .flexslider .slides .overlay {
+  background: rgba(0, 0, 0, 0.4);
+}

--- a/templates/partial/hero.html
+++ b/templates/partial/hero.html
@@ -1,9 +1,9 @@
 {% if HERO|length > 0 %}
-<aside id="fh5co-hero" class="js-fullheight">
+<aside id="fh5co-hero" class="js-fullheight space-ros">
     <div class="flexslider js-fullheight">
         <ul class="slides">
             {% for hero in HERO %}
-                <li style="background-image: url({{ SITEURL}}{{ hero.image }});">
+                <li style="background-image: url({{ SITEURL }}{{ hero.image }});">
                     <div class="overlay"></div>
                     <div class="container-fluid">
                         <div class="row">
@@ -16,7 +16,7 @@
                                             <h1>{{ hero.title[DEFAULT_LANG] }}</h1>
                                         {% endif %}
                                     {% endif %}
-                                    
+
                                     {% if 'text' in hero %}
                                         {% if hero.text is string %}
                                             <h2>{{ hero.text }}</h2>
@@ -24,7 +24,7 @@
                                             <h2>{{ hero.text[DEFAULT_LANG] }}</h2>
                                         {% endif %}
                                     {% endif %}
-                                    
+
                                     <p>
                                         {% for link in hero.links %}
                                             <a class="btn btn-primary" href="{{ link.url }}">


### PR DESCRIPTION
The following changes are intended to make the text stand out of the background a little more. Addresses https://github.com/space-ros/spaceros.org/issues/15.

Changes include:
- Updating the background's color to have an opacity of 0.4.
  
  Originally, the hero images have a black overlay with an opacity of 0.3. Making it a little darker makes it easier for the text to stand out, without making the image too dark.
  
- Adding `text-shadow` to the text surrounds it with a slight shadow.

Another potential change that could help this is to increase the font weight, but I think that having a bolder font goes against the feel of the page.

**Note:** This does not change the text color of the hamburguer icon - It will be handled in a sepparate PR.

Can you ptal @mjeronimo ?

---

## Screenshots

Open the images in a new tab for better comparison.

| Before | After |
| --- | --- |
| ![localhost_8081_ (4)](https://user-images.githubusercontent.com/14120807/206471543-5575e447-a64c-464f-a32d-47660ba18153.png) | ![localhost_8081_ (1)](https://user-images.githubusercontent.com/14120807/206471671-0b773937-984f-481a-af73-a5375b877141.png) |
| ![localhost_8081_ (3)](https://user-images.githubusercontent.com/14120807/206471560-421db84f-ecfa-45ec-adcc-f4e5bb1b5348.png) | ![localhost_8081_ (2)](https://user-images.githubusercontent.com/14120807/206471625-bb7bc6b2-68e0-4c14-8fea-186b5c8b7c59.png) |
