### PR TITLE
White Toggle Button

### DIFF
--- a/static/css/space-ros.css
+++ b/static/css/space-ros.css
@@ -56,3 +56,16 @@
 #fh5co-hero .flexslider .slides .overlay {
   background: rgba(0, 0, 0, 0.4);
 }
+
+/* Colorize the Toggle button */
+.fh5co-nav-toggle i {
+  background: white;
+}
+
+.fh5co-nav-toggle i::before, .fh5co-nav-toggle i::after {
+  background: white;
+}
+
+.fh5co-nav-toggle.active i::before, .fh5co-nav-toggle.active i::after {
+  background: white;
+}

--- a/static/css/space-ros.css
+++ b/static/css/space-ros.css
@@ -58,6 +58,10 @@
 }
 
 /* Colorize the Toggle button */
+.fh5co-nav-toggle {
+  mix-blend-mode: difference;
+}
+
 .fh5co-nav-toggle i {
   background: white;
 }


### PR DESCRIPTION
This PR addresses part of https://github.com/space-ros/spaceros.org/issues/16

The sidenav toggle button is now white and has a _difference_ blend, making it stand out over any backgrounds.

Can you ptal @mjeronimo ?

---

## GIF

![spaceROS-toggle-btn-002](https://user-images.githubusercontent.com/14120807/206537329-d272f110-606e-4bfb-bc04-2a56ccf877a2.gif)
